### PR TITLE
Simplify password authentication by removing the check of last log out time vs. log in time

### DIFF
--- a/pypi_package/src/streamlit_supabase_auth_ui/utils.py
+++ b/pypi_package/src/streamlit_supabase_auth_ui/utils.py
@@ -36,7 +36,7 @@ def welcome_w_email(auth_token: str, username_forgot_passwd: str, email_forgot_p
     }
     )
 
-def check_usr_pass(username: str, password: str) -> bool | None:
+def check_usr_pass(username: str, password: str) -> bool:
     """
     Authenticates the username and password.
     """

--- a/pypi_package/src/streamlit_supabase_auth_ui/utils.py
+++ b/pypi_package/src/streamlit_supabase_auth_ui/utils.py
@@ -42,11 +42,8 @@ def check_usr_pass(username: str, password: str) -> bool | None:
     """
     query = supabase.from_("user_authentication").select("*").eq("username", username).eq("password", ph.hash(password)).execute()
     if len(query.data) > 0:
-        if query.data[0]["last_logout"] < query.data[0]["last_login"]:
-            return None
-        else:
-            supabase.table("user_authentication").update({"last_login": time.time()}).eq("username", username).execute()
-            return True
+        supabase.table("user_authentication").update({"last_login": time.time()}).eq("username", username).execute()
+        return True
     return False
 
 

--- a/streamlit_supabase_auth_ui/utils.py
+++ b/streamlit_supabase_auth_ui/utils.py
@@ -36,17 +36,14 @@ def welcome_w_email(auth_token: str, username_forgot_passwd: str, email_forgot_p
     }
     )
 
-def check_usr_pass(username: str, password: str) -> bool | None:
+def check_usr_pass(username: str, password: str) -> bool:
     """
     Authenticates the username and password.
     """
     query = supabase.from_("user_authentication").select("*").eq("username", username).eq("password", ph.hash(password)).execute()
     if len(query.data) > 0:
-        if query.data[0]["last_logout"] < query.data[0]["last_login"]:
-            return None
-        else:
-            supabase.table("user_authentication").update({"last_login": time.time()}).eq("username", username).execute()
-            return True
+        supabase.table("user_authentication").update({"last_login": time.time()}).eq("username", username).execute()
+        return True
     return False
 
 


### PR DESCRIPTION
This is to resolve #7 

If users do not press the logout button and directly refresh the webpage, the last logout time is going to be less than the login time, and it will lock the login and users do not have a way to unlock it without resetting the password. 

Wonder why the source code checks logout time vs. login time in the beginning, is it mandatory?